### PR TITLE
Fix grep warning

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -18,7 +18,11 @@ elif grep-flag-available --exclude=.cvs; then
         GREP_OPTIONS+=" --exclude=$PATTERN"
     done
 fi
-unfunction grep-flag-available
 
-export GREP_OPTIONS="$GREP_OPTIONS"
+# export grep settings
+alias grep="grep $GREP_OPTIONS"
 export GREP_COLOR='1;32'
+
+#clean
+unset GREP_OPTIONS
+unfunction grep-flag-available


### PR DESCRIPTION
Fixed  `grep: warning: GREP_OPTIONS is deprecated; please use an alias or script`